### PR TITLE
feat: adicionar mock de dados para starships via injection token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -337,6 +337,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-15.2.9.tgz",
       "integrity": "sha512-GQujLhI0cQFcl4Q8y0oSYKSRnW23GIeSL+Arl4eFufziJ9hGAAQNuesaNs/7i+9UlTHDMkPH3kd5ScXuYYz6wg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -425,6 +426,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-15.2.9.tgz",
       "integrity": "sha512-LM9/UHG2dRrOzlu2KovrFwWIziFMjRxHzSP3Igw6Symw/wIl0kXGq8Fn6RpFP78zmLqnv+IQOoRiby9MCXsI4g==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -440,6 +442,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-15.2.9.tgz",
       "integrity": "sha512-MoKugbjk+E0wRBj12uvIyDLELlVLonnqjA2+XiF+7FxALIeyds3/qQeEoMmYIqAbN3NnTT5pV92RxWwG4tHFwA==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -460,6 +463,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-15.2.9.tgz",
       "integrity": "sha512-zsbI8G2xHOeYWI0hjFzrI//ZhZV9il/uQW5dAimfwJp06KZDeXZ3PdwY9JQslf6F+saLwOObxy6QMrIVvfjy9w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.19.3",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -540,6 +544,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-15.2.9.tgz",
       "integrity": "sha512-w46Z1yUXCQfKV7XfnamOoLA2VD0MVUUYVrUjO73mHSskDXSXxfZAEHO9kfUS71Cj35PvhP3mbkqWscpea2WeYg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -555,6 +560,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-15.2.9.tgz",
       "integrity": "sha512-sk0pC2EFi2Ohg5J0q0NYptbT+2WOkoiERSMYA39ncDvlSZBWsNlxpkbGUSck7NIxjK2QfcVN1ldGbHlZTFvtqg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -636,6 +642,7 @@
       "version": "15.2.9",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-15.2.9.tgz",
       "integrity": "sha512-ufCHeSX+U6d43YOMkn3igwfqtlozoCXADcbyfUEG8m2y9XASobqmCKvdSk/zfl62oyiA8msntWBJVBE2l4xKXg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -719,6 +726,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
       "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -4620,6 +4628,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4707,6 +4716,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -5128,6 +5138,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -7984,7 +7995,8 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.5.0.tgz",
       "integrity": "sha512-9PMzyvhtocxb3aXJVOPqBDswdgyAeSB81QnLop4npOpbqnheaTEwPc9ZloQeVswugPManznQBjD8kWDTjlnHuw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -8108,6 +8120,7 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.2.tgz",
       "integrity": "sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -8194,6 +8207,7 @@
       "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-5.1.0.tgz",
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -10076,6 +10090,7 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -10767,6 +10782,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10807,6 +10823,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.58.1.tgz",
       "integrity": "sha512-bnINi6nPXbP1XNRaranMFEBZWUfdW/AF16Ql5+ypRxfTvCRTTKrLsMIakyDcayUt2t/RZotmL4kgJwNH5xO+bg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -11697,6 +11714,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11939,6 +11957,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12187,6 +12206,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.1.tgz",
       "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -12257,6 +12277,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
       "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -12378,6 +12399,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12655,6 +12677,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.12.0.tgz",
       "integrity": "sha512-XtC+I5dXU14HrzidAKBNMqneIVUykLEAA1x+v4KVrd6AUPWlwYORF8KgsVqvgdHiKZ4BkxxjvYi/ksEixTPR0Q==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,6 +8,9 @@ import { routes } from './app.routes';
 import { MOVIES_SERVICE } from './features/movies/data/movies-service.token';
 import { MoviesFakeService } from './features/movies/data/services/movies-fake.service';
 import { MoviesService } from './features/movies/data/services/movies.service';
+import { STARSHIPS_SERVICE } from './features/starships/data/starships-service.token';
+import { StarshipsFakeService } from './features/starships/data/services/starships-fake.service';
+import { StarshipsService } from './features/starships/data/services/starships.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -17,6 +20,10 @@ export const appConfig: ApplicationConfig = {
     {
       provide: MOVIES_SERVICE,
       useFactory: () => environment.useFakeMoviesData ? inject(MoviesFakeService) : inject(MoviesService)
+    },
+    {
+      provide: STARSHIPS_SERVICE,
+      useFactory: () => environment.useFakeStarshipsData ? inject(StarshipsFakeService) : inject(StarshipsService)
     }
   ]
 };

--- a/src/app/features/starships/data/services/starships-fake.service.spec.ts
+++ b/src/app/features/starships/data/services/starships-fake.service.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StarshipsFakeService } from './starships-fake.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('StarshipsFakeService', () => {
+  let service: StarshipsFakeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ]
+    });
+    service = TestBed.inject(StarshipsFakeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/features/starships/data/services/starships-fake.service.ts
+++ b/src/app/features/starships/data/services/starships-fake.service.ts
@@ -1,0 +1,47 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { IStarship, IStarshipItem } from '../interfaces/starship';
+import { IStarshipsService } from '../starships-service.token';
+
+interface IStarshipFake {
+  results: IStarshipItem[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StarshipsFakeService implements IStarshipsService {
+  private readonly pageSize = 10;
+
+  constructor(private httpClient: HttpClient) { }
+
+  getAll(page: number = 1): Observable<IStarship> {
+    return this.httpClient.get<IStarshipFake>(environment.baseApiStarshipsFake).pipe(
+      map(data => this.paginate(data.results, page))
+    );
+  }
+
+  getSearch(query: string): Observable<IStarship> {
+    return this.httpClient.get<IStarshipFake>(environment.baseApiStarshipsFake).pipe(
+      map(data => data.results.filter(starship =>
+        starship.name.toLowerCase().includes(query.toLowerCase()) ||
+        starship.model.toLowerCase().includes(query.toLowerCase()) ||
+        starship.starship_class.toLowerCase().includes(query.toLowerCase())
+      )),
+      map(results => this.paginate(results, 1))
+    );
+  }
+
+  private paginate(results: IStarshipItem[], page: number): IStarship {
+    const start = (page - 1) * this.pageSize;
+
+    return {
+      count: results.length,
+      next: start + this.pageSize < results.length ? 'next' : '',
+      previous: null,
+      results: results.slice(start, start + this.pageSize)
+    };
+  }
+}

--- a/src/app/features/starships/data/services/starships.service.ts
+++ b/src/app/features/starships/data/services/starships.service.ts
@@ -3,11 +3,12 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { IStarship } from '../interfaces/starship';
+import { IStarshipsService } from '../starships-service.token';
 
 @Injectable({
   providedIn: 'root'
 })
-export class StarshipsService {
+export class StarshipsService implements IStarshipsService {
   private readonly baseUrl = environment.swapiAPIObject.base.url + environment.swapiAPIObject.resources.starships;
 
   constructor(private httpClient: HttpClient) { }

--- a/src/app/features/starships/data/starships-service.token.ts
+++ b/src/app/features/starships/data/starships-service.token.ts
@@ -1,0 +1,10 @@
+import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
+import { IStarship } from './interfaces/starship';
+
+export interface IStarshipsService {
+  getAll(page?: number): Observable<IStarship>;
+  getSearch(query: string): Observable<IStarship>;
+}
+
+export const STARSHIPS_SERVICE = new InjectionToken<IStarshipsService>('STARSHIPS_SERVICE');

--- a/src/app/features/starships/starships.component.spec.ts
+++ b/src/app/features/starships/starships.component.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 
 import { StarshipsComponent } from './starships.component';
 import { HttpClient, HttpHandler } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { STARSHIPS_SERVICE } from './data/starships-service.token';
 
 describe('StarshipsComponent', () => {
   let component: StarshipsComponent;
@@ -16,7 +18,14 @@ describe('StarshipsComponent', () => {
       providers: [
         HttpClient,
         HttpHandler,
-        provideAnimations()
+        provideAnimations(),
+        {
+          provide: STARSHIPS_SERVICE,
+          useValue: {
+            getAll: () => of({ count: 0, next: '', previous: null, results: [] }),
+            getSearch: () => of({ count: 0, next: '', previous: null, results: [] })
+          }
+        }
       ]
     })
     .compileComponents();

--- a/src/app/features/starships/starships.component.ts
+++ b/src/app/features/starships/starships.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -6,7 +6,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
-import { StarshipsService } from './data/services/starships.service';
+import { STARSHIPS_SERVICE } from './data/starships-service.token';
 import { Subject, combineLatest, debounceTime, distinctUntilChanged, filter, map, switchMap, takeUntil, tap } from 'rxjs';
 import { IStarshipItem } from './data/interfaces/starship';
 import { trigger, state, style, transition, animate } from '@angular/animations';
@@ -38,6 +38,8 @@ import { LoadingComponent } from '../shared/components/loading/loading.component
 })
 
 export class StarshipsComponent implements OnInit, OnDestroy {
+
+  private readonly starshipsService = inject(STARSHIPS_SERVICE);
 
   starshipInputSearch = new FormControl('', { nonNullable: true });
   starships: IStarshipItem[] = [];
@@ -74,8 +76,6 @@ export class StarshipsComponent implements OnInit, OnDestroy {
   expandedElement: StarshipDetails | undefined;
 
   private readonly destroyed$ = new Subject<void>();
-
-  constructor(private starshipsService: StarshipsService) {}
 
   ngOnInit(): void {
     const observables = {

--- a/src/assets/data/starships.json
+++ b/src/assets/data/starships.json
@@ -1,0 +1,190 @@
+{
+  "results": [
+    {
+      "name": "CR90 corvette",
+      "model": "CR90 corvette",
+      "manufacturer": "Corellian Engineering Corporation",
+      "cost_in_credits": "3500000",
+      "length": "150",
+      "max_atmosphering_speed": "950",
+      "crew": "30-165",
+      "passengers": "600",
+      "cargo_capacity": "3000000",
+      "consumables": "1 year",
+      "hyperdrive_rating": "2.0",
+      "MGLT": "60",
+      "starship_class": "corvette",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/",
+        "https://swapi.dev/api/films/3/",
+        "https://swapi.dev/api/films/6/"
+      ],
+      "created": "2014-12-10T14:20:33.369000Z",
+      "edited": "2014-12-20T21:23:49.867000Z",
+      "url": "https://swapi.dev/api/starships/2/"
+    },
+    {
+      "name": "Star Destroyer",
+      "model": "Imperial I-class Star Destroyer",
+      "manufacturer": "Kuat Drive Yards",
+      "cost_in_credits": "150000000",
+      "length": "1,600",
+      "max_atmosphering_speed": "975",
+      "crew": "47,060",
+      "passengers": "n/a",
+      "cargo_capacity": "36000000",
+      "consumables": "2 years",
+      "hyperdrive_rating": "2.0",
+      "MGLT": "60",
+      "starship_class": "Star Destroyer",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/",
+        "https://swapi.dev/api/films/2/",
+        "https://swapi.dev/api/films/3/"
+      ],
+      "created": "2014-12-10T15:08:19.848000Z",
+      "edited": "2014-12-20T21:23:49.870000Z",
+      "url": "https://swapi.dev/api/starships/3/"
+    },
+    {
+      "name": "Sentinel-class landing craft",
+      "model": "Sentinel-class landing craft",
+      "manufacturer": "Sienar Fleet Systems, Cyngus Spacewords",
+      "cost_in_credits": "240000",
+      "length": "38",
+      "max_atmosphering_speed": "1000",
+      "crew": "5",
+      "passengers": "75",
+      "cargo_capacity": "180000",
+      "consumables": "1 month",
+      "hyperdrive_rating": "1.0",
+      "MGLT": "70",
+      "starship_class": "landing craft",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/"
+      ],
+      "created": "2014-12-10T15:48:00.586000Z",
+      "edited": "2014-12-20T21:23:49.873000Z",
+      "url": "https://swapi.dev/api/starships/5/"
+    },
+    {
+      "name": "Death Star",
+      "model": "DS-1 Orbital Battle Station",
+      "manufacturer": "Imperial Department of Military Research, Sienar Fleet Systems",
+      "cost_in_credits": "1000000000000",
+      "length": "120000",
+      "max_atmosphering_speed": "n/a",
+      "crew": "342953",
+      "passengers": "843342",
+      "cargo_capacity": "1000000000000",
+      "consumables": "3 years",
+      "hyperdrive_rating": "4.0",
+      "MGLT": "10",
+      "starship_class": "Deep Space Mobile Battlestation",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/"
+      ],
+      "created": "2014-12-10T16:36:50.509000Z",
+      "edited": "2014-12-20T21:26:24.783000Z",
+      "url": "https://swapi.dev/api/starships/9/"
+    },
+    {
+      "name": "Millennium Falcon",
+      "model": "YT-1300 light freighter",
+      "manufacturer": "Corellian Engineering Corporation",
+      "cost_in_credits": "100000",
+      "length": "34.37",
+      "max_atmosphering_speed": "1050",
+      "crew": "4",
+      "passengers": "6",
+      "cargo_capacity": "100000",
+      "consumables": "2 months",
+      "hyperdrive_rating": "0.5",
+      "MGLT": "75",
+      "starship_class": "Light freighter",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/",
+        "https://swapi.dev/api/films/2/",
+        "https://swapi.dev/api/films/3/"
+      ],
+      "created": "2014-12-10T16:59:45.094000Z",
+      "edited": "2014-12-20T21:23:49.880000Z",
+      "url": "https://swapi.dev/api/starships/10/"
+    },
+    {
+      "name": "Y-wing",
+      "model": "BTL Y-wing",
+      "manufacturer": "Koensayr Manufacturing",
+      "cost_in_credits": "134999",
+      "length": "14",
+      "max_atmosphering_speed": "1000km",
+      "crew": "2",
+      "passengers": "0",
+      "cargo_capacity": "110",
+      "consumables": "1 week",
+      "hyperdrive_rating": "1.0",
+      "MGLT": "80",
+      "starship_class": "assault starfighter",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/",
+        "https://swapi.dev/api/films/2/",
+        "https://swapi.dev/api/films/3/"
+      ],
+      "created": "2014-12-12T11:00:39.817000Z",
+      "edited": "2014-12-20T21:23:49.883000Z",
+      "url": "https://swapi.dev/api/starships/11/"
+    },
+    {
+      "name": "X-wing",
+      "model": "T-65 X-wing",
+      "manufacturer": "Incom Corporation",
+      "cost_in_credits": "149999",
+      "length": "12.5",
+      "max_atmosphering_speed": "1050",
+      "crew": "1",
+      "passengers": "0",
+      "cargo_capacity": "110",
+      "consumables": "1 week",
+      "hyperdrive_rating": "1.0",
+      "MGLT": "100",
+      "starship_class": "Starfighter",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/",
+        "https://swapi.dev/api/films/2/",
+        "https://swapi.dev/api/films/3/"
+      ],
+      "created": "2014-12-12T11:19:05.340000Z",
+      "edited": "2014-12-20T21:23:49.886000Z",
+      "url": "https://swapi.dev/api/starships/12/"
+    },
+    {
+      "name": "TIE Advanced x1",
+      "model": "Twin Ion Engine Advanced x1",
+      "manufacturer": "Sienar Fleet Systems",
+      "cost_in_credits": "unknown",
+      "length": "9.2",
+      "max_atmosphering_speed": "1200",
+      "crew": "1",
+      "passengers": "0",
+      "cargo_capacity": "150",
+      "consumables": "5 days",
+      "hyperdrive_rating": "1.0",
+      "MGLT": "105",
+      "starship_class": "Starfighter",
+      "pilots": [],
+      "films": [
+        "https://swapi.dev/api/films/1/"
+      ],
+      "created": "2014-12-12T11:21:32.991000Z",
+      "edited": "2014-12-20T21:23:49.889000Z",
+      "url": "https://swapi.dev/api/starships/13/"
+    }
+  ]
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -20,6 +20,8 @@ const swapiAPIObject: ISwapi = {
 export const environment = {
    production: false,
    useFakeMoviesData: true,
+   useFakeStarshipsData: true,
    baseApiFilmsFake: 'assets/data/films.json',
+   baseApiStarshipsFake: 'assets/data/starships.json',
    swapiAPIObject: swapiAPIObject
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,6 +20,8 @@ const swapiAPIObject: ISwapi = {
 export const environment = {
    production: true,
    useFakeMoviesData: false,
+   useFakeStarshipsData: false,
    baseApiFilmsFake: 'assets/data/films.json',
+   baseApiStarshipsFake: 'assets/data/starships.json',
    swapiAPIObject: swapiAPIObject
 };


### PR DESCRIPTION
A API remota swapi.dev esta fora do ar, entao StarshipsComponent passa a usar o mesmo padrao ja aplicado em MoviesComponent: um injection token (STARSHIPS_SERVICE) que alterna entre o servico real (StarshipsService) e um fake (StarshipsFakeService) conforme environment.useFakeStarshipsData.

- cria starships-service.token.ts com a interface IStarshipsService
- cria StarshipsFakeService, que le assets/data/starships.json e reproduz paginacao/busca localmente
- popula starships.json com os dados extraidos do screenshot da API (CR90 corvette, Star Destroyer, Sentinel-class landing craft, Death Star, Millennium Falcon, Y-wing, X-wing e TIE Advanced x1)
- StarshipsService passa a implementar IStarshipsService
- StarshipsComponent injeta STARSHIPS_SERVICE em vez do servico concreto
- registra o provider em app.config.ts e os novos campos em environment.ts/environment.development.ts