### PR TITLE
fix: alteração provisória para consumir o mock de dados até estabiliz…

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -18,9 +18,9 @@ const swapiAPIObject: ISwapi = {
 };
 
 export const environment = {
-   production: true,
-   useFakeMoviesData: false,
-   useFakeStarshipsData: false,
+   production: false,
+   useFakeMoviesData: true,
+   useFakeStarshipsData: true,
    baseApiFilmsFake: 'assets/data/films.json',
    baseApiStarshipsFake: 'assets/data/starships.json',
    swapiAPIObject: swapiAPIObject


### PR DESCRIPTION
…ar a API remota.

A API remota (https://swapi.dev/api) está fora ou foi descontinuada. Essa correção foi aplicada temporariamente para produção consumir os dados mockados e não quebrar a visualização e as funcionalidades da tela.